### PR TITLE
[ISAGD-6477] Fixed bad error message

### DIFF
--- a/src/path-v3-generator/path-v3-generator.js
+++ b/src/path-v3-generator/path-v3-generator.js
@@ -45,23 +45,22 @@ function createPathV3Generator( options ) {
         "readable": createReadable,
     };
     function createReadable(){
-        // Evaluation of apiName simply copy-pasted from 2ndGen path generator.
-        const rootClassName = JavaGen.classOf((openApi.info || {}).title || '');
-        const paths = (openApi.paths || {});
-        var rootNode;
         try{
-            rootNode = transformPathsToTree( paths ); // May throws in case slashing isn't valid.
+            // Evaluation of apiName simply copy-pasted from 2ndGen path generator.
+            const rootClassName = JavaGen.classOf((openApi.info || {}).title || '');
+            const paths = (openApi.paths || {});
+            const rootNode = transformPathsToTree( paths );
             throwIfTreeWouldProduceNameConflict( rootNode );
+            const firstNodeAfterBasePath = shiftAwayBasePath( rootNode , pathPrefix );
+            const fileBeginReadable = StreamUtils.streamFromString( "package "+ javaPackage +";\n\n" );
+            const rootClass = createClass( rootClassName , firstNodeAfterBasePath , pathPrefix );
+            return StreamUtils.streamConcat([
+                fileBeginReadable,
+                rootClass.readable()
+            ]);
         }catch( e ){
             return StreamUtils.streamFromError( e );
         }
-        const firstNodeAfterBasePath = shiftAwayBasePath( rootNode , pathPrefix );
-        const fileBeginReadable = StreamUtils.streamFromString( "package "+ javaPackage +";\n\n" );
-        const rootClass = createClass( rootClassName , firstNodeAfterBasePath , pathPrefix );
-        return StreamUtils.streamConcat([
-            fileBeginReadable,
-            rootClass.readable()
-        ]);
     }
 }
 
@@ -355,6 +354,9 @@ function createJavaVariable( options ) {
  *		passed map as paths.
  * @return {Map<string,Map<any>>}
  *		A tree representing the passed in paths.
+ * @throws Error
+ *      In case there's something wrong with slashes. Eg: leading slash
+ *      missing.
  */
 function transformPathsToTree( paths ){
     const segments2d = splitAllPathsToArrays( paths );
@@ -377,9 +379,12 @@ function transformPathsToTree( paths ){
  *      Path to remove from specified rootNode.
  * @return
  *      Node representing latest segment present in specified pathPrefix.
+ * @throws Error
+ *      In case there is a path which doesn't fit into path-prefix.
  */
 function shiftAwayBasePath( node , pathPrefix ){
     pathPrefix = UrlUtils.dropSurroundingSlashes( pathPrefix );
+    const segmentStack = [];
     if( !pathPrefix || pathPrefix.length === 0 ){
         return node;
     }
@@ -388,14 +393,26 @@ function shiftAwayBasePath( node , pathPrefix ){
         const key = pathPrefix[i];
         const actualKeys = Object.keys( node );
         if( actualKeys.length > 1 ){
-            delete actualKeys[key];  // Remove correct key.
-            const exampleKey = actualKeys[0];  // Take a random bad key.
-            // TODO: Provide full path (not only segment) in this error msg.
-            throw Error( "Segment '"+exampleKey+"' doesn't fit into pathPrefix" );
+            // Collect data for error msg.
+            var badKey = null;
+            for( let i=0 ; i<actualKeys.length ; ++i ){
+                if( actualKeys[i] !== key ){
+                    badKey = actualKeys[i];
+                    break;
+                }
+            }
+            var fullPath = '/'+ segmentStack.join('/');
+            if( !fullPath.endsWith('/') ){ fullPath+='/'; }
+            fullPath += badKey;
+            for( let x=node[badKey],subKey ; subKey=Object.keys(x)[0] ; x=x[subKey] ){
+                fullPath += '/'+ subKey;
+            }
+            throw Error( "Path '"+fullPath+"' doesn't fit into path-prefix '/"+pathPrefix.join('/')+"/'" );
         }else if( actualKeys[0] !== key ){
             // TODO: Provide full path (not only segment) in this error msg.
             throw Error( "Segment '"+actualKeys[0]+"' doesn't fit into pathPrefix" );
         }
+        segmentStack.push( key );
         node = node[key]; // Shift down one step.
     }
     return node;

--- a/test/specs/path-v3-generator.spec.js
+++ b/test/specs/path-v3-generator.spec.js
@@ -674,6 +674,84 @@ describe( "PathV3Generator" , ()=>{
     });
 
 
+    it( "Will fail-fast if 1st segment of a path doesn't match path-prefix" , function( done ){
+        const victim = PathV3Generator.createPathV3Generator({
+            openApi: {
+                info: {
+                    title: "foo blubb API",
+                },
+                paths: {
+                    "/foo/v1/one": null,
+                    "/foo/v1/two": null,
+                    "/bar/v1/a-bad-one": null,
+                    "/foo/v1/three": null,
+                }
+            },
+            javaPackage: "com.example",
+            pathPrefix: "foo/v1/",
+        });
+
+        const myFail = function( ctxt ){
+            if( ctxt.alreadyFailed ){ return; }else{ ctxt.alreadyFailed=true; }
+            fail( "No data expected" );
+            done();
+        }.bind(0,{ alreadyFailed:false });
+
+        victim.readable()
+            // Neither data nor end expected.
+            .on( "data" , myFail ).on( "end" , myFail )
+            // We only expect an error.
+            .on( "error" , function( err ){
+                const msg = err.message;
+                // The path is mentioned.
+                expect( msg ).toContain( "/bar/v1/a-bad-one" );
+                // Also the path-prefix is mentioned.
+                expect( msg ).toContain( "foo/v1/" );
+                done();
+            })
+        ;
+    });
+
+
+    it( "Will fail-fast if there's a segment somewhere in path not matching path-prefix" , function( done ){
+        const victim = PathV3Generator.createPathV3Generator({
+            openApi: {
+                info: {
+                    title: "foo blubb API",
+                },
+                paths: {
+                    "/foo/blubb/api/v1/one": null,
+                    "/foo/blubb/api/v2/a-bad-one": null,
+                    "/foo/blubb/api/v1/two": null,
+                    "/foo/blubb/api/v1/three": null,
+                }
+            },
+            javaPackage: "com.example",
+            pathPrefix: "foo/blubb/api/v1/",
+        });
+
+        const myFail = function( ctxt ){
+            if( ctxt.alreadyFailed ){ return; }else{ ctxt.alreadyFailed=true; }
+            fail( "No data expected" );
+            done();
+        }.bind(0,{ alreadyFailed:false });
+
+        victim.readable()
+            // Neither data nor end expected.
+            .on( "data" , myFail ).on( "end" , myFail )
+            // We only expect an error.
+            .on( "error" , function( err ){
+                const msg = err.message;
+                // The path is mentioned.
+                expect( msg ).toContain( "/foo/blubb/api/v2/a-bad-one" );
+                // Also the path-prefix is mentioned.
+                expect( msg ).toContain( "foo/blubb/api/v1/" );
+                done();
+            })
+        ;
+    });
+
+
 });
 
 


### PR DESCRIPTION
In case a path doesn't fit path-prefix, the error message printed the
valid segment instead the invalid one. This is now fixed. Also the error
message got improved and now contains the whole path which is bad and
also includes correct path-prefix.