### PR TITLE
Make 1st and 2nd generation paths deactivatable

### DIFF
--- a/src/generate-constants.js
+++ b/src/generate-constants.js
@@ -12,7 +12,11 @@ var OldJavaGen = require('./generate-old-java-constants');
 var TsGen = require('./generate-ts-constants');
 
 module.exports = {
-    generate: function (source, dest) {
+    generate: function (source, dest, options) {
+        if( !options ){ options = {}; }
+        const generate1stGenPaths = !!options.generate1stGenPaths;
+        const generate2ndGenPaths = !!options.generate2ndGenPaths;
+        options = null; // Prevent further access.
         return source
             .pipe(createConstantsFile(params.javaPackage()))
             .pipe(dest);
@@ -32,10 +36,20 @@ module.exports = {
                         basePath = api.basePath;
                         log.debug( "Using BASE_PATH='"+basePath+"' from api file." );
                     }
-                    this.push(generate(new JavaPathsGen(model, javaPackage, apiName, api.host, basePath)));
-                    this.push(generate(new JavaPathVarsGen(model, javaPackage, apiName, api.host, basePath)));
-                    this.push(generate(new JavaBuilderGen(model, javaPackage, apiName, api.host, basePath)));
-                    this.push(generate(new OldJavaGen(model, javaPackage, apiName)));
+                    if( generate2ndGenPaths ){
+                        log.debug( "options.generate2ndGenPaths=true -> Generate." );
+                        this.push(generate(new JavaPathsGen(model, javaPackage, apiName, api.host, basePath)));
+                        this.push(generate(new JavaPathVarsGen(model, javaPackage, apiName, api.host, basePath)));
+                        this.push(generate(new JavaBuilderGen(model, javaPackage, apiName, api.host, basePath)));
+                    }else{
+                        log.debug( "options.generate2ndGenPaths=false -> Don't generate." );
+                    }
+                    if( generate1stGenPaths ){
+                        log.debug( "options.generate1stGenPaths=true -> Generate." );
+                        this.push(generate(new OldJavaGen(model, javaPackage, apiName)));
+                    }else{
+                        log.debug( "options.generate1stGenPaths=false -> Don't generate." );
+                    }
                 }
                 this.push(generate(new TsGen(model, apiName, api.host, api.basePath)));
                 cb();

--- a/src/generate.js
+++ b/src/generate.js
@@ -236,16 +236,22 @@ module.exports = {
             if (restApi.paths == null || restApi.paths.length === 0) {
                 return emptyStream();
             }
+            const generate1stGenPaths = params.generate1stGenPaths();
+            const generate2ndGenPaths = params.generate2ndGenPaths();
+            log.info( "1st generation paths are "+(generate1stGenPaths?"\x1b[1;35menabled ":"\x1b[35mdisabled")+"\x1b[0m (--generate1stGenPaths="+generate1stGenPaths+")." );
+            log.info( "2nd generation paths are "+(generate2ndGenPaths?"\x1b[1;35menabled ":"\x1b[35mdisabled")+"\x1b[0m (--generate2ndGenPaths="+generate2ndGenPaths+")." );
             return require('./generate-constants').generate(
                 gulp.src(params.api(), {cwd: source}),
-                gulp.dest('model', {cwd: dest}));
+                gulp.dest('model', {cwd: dest}),
+                { generate1stGenPaths:generate1stGenPaths , generate2ndGenPaths:generate2ndGenPaths }
+            );
         });
 
         task('generate-3rdGen-constants', ['copy-src','read-rest-api'], function(){
             const generate3rdGenPaths = params.generate3rdGenPaths();
             const gulpOStream = gulp.dest( "model/" , {cwd: dest});
+            log.info( "3rd generation paths are "+(generate3rdGenPaths?"\x1b[1;35menabled ":"\x1b[35mdisabled")+"\x1b[0m (--generate3rdGenPaths="+generate3rdGenPaths+")." );
             if( !generate3rdGenPaths ){
-                log.warn( "3rd generation paths are disabled (--generate3rdGenPaths). Skip." );
                 return StreamUtils.emptyStream().pipe( gulpOStream );
             }
             const javaPackage = params.javaPackage() +".path";

--- a/src/params.js
+++ b/src/params.js
@@ -82,6 +82,30 @@ module.exports = {
     minVersion: function () {
         return env.minVersion;
     },
+    generate1stGenPaths: function(){
+        const input = env["generate1stGenPaths"];
+        var result;
+        if( input===undefined ){
+            result = true; // Enabled by default.
+        }else if( input.toUpperCase()==="FALSE" ){
+            result = false;
+        }else{
+            result = true;
+        }
+        return result;
+    },
+    generate2ndGenPaths: function(){
+        const input = env["generate2ndGenPaths"];
+        var result;
+        if( input===undefined ){
+            result = true; // Enabled by default.
+        }else if( input.toUpperCase()==="FALSE" ){
+            result = false;
+        }else{
+            result = true;
+        }
+        return result;
+    },
     generate3rdGenPaths: function(){
         const input = env["generate3rdGenPaths"];
         var result;


### PR DESCRIPTION
- Add command line switches to enable/disable 1st and 2nd generation
  path constant generators.
- Set them enabled by default to keep backward compatibility.