### PR TITLE
Fix NullPointer When Generating Error Msg If Path Is Shorter Than pathPrefix

### DIFF
--- a/src/path-v3-generator/path-v3-generator.js
+++ b/src/path-v3-generator/path-v3-generator.js
@@ -435,10 +435,12 @@ function shiftAwayBasePath( node , pathPrefix ){
         var fullPath = '/'+ segmentStack.join('/');
         // Append the current segment.
         if( !fullPath.endsWith('/') ){ fullPath+='/'; }
-        fullPath += badKey;
-        // Also append the later segments we've not iterated yet.
-        for( let it=node[badKey],subKey ; subKey=Object.keys(it)[0] ; it=it[subKey] ){
-            fullPath += '/'+ subKey;
+        if(badKey){
+            fullPath += badKey;
+            // Also append the later segments we've not iterated yet. (If there are some available).
+            for( let it=node[badKey],subKey ; subKey=Object.keys(it)[0] ; it=it[subKey] ){
+                fullPath += '/'+ subKey;
+            }
         }
         throw Error( "Path '"+fullPath+"' doesn't fit into path-prefix '/"+pathPrefix.join('/')+"/'" );
     }


### PR DESCRIPTION
That patch fill fix following misleading error message:

**Given:**
- `--generate3rdGenPaths=true`
- pathPrefix `one/two/three/`
- Path in api.yaml `/one/two`

**Actual:**
```
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at throwSegmentMismatchError (C:\work\projects\swisspush\apikana-installed\src\path-v3-generator\path-v3-generator.js:440:57)
    at shiftAwayBasePath (C:\work\projects\swisspush\apikana-installed\src\path-v3-generator\path-v3-generator.js:419:13)
    at Object.createReadable [as readable] (C:\work\projects\swisspush\apikana-installed\src\path-v3-generator\path-v3-generator.js:54:44)
    at Readable.read [as _read] (C:\work\projects\swisspush\apikana-installed\src\generate.js:273:22)
    at Readable.read (_stream_readable.js:442:10)
    at resume_ (_stream_readable.js:822:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```

**Expected:**
```

Error: Path '/one/two/' doesn't fit into path-prefix '/one/two/three'
    at throwSegmentMismatchError (C:\work\projects\swisspush\apikana\src\path-v3-generator\path-v3-generator.js:445:15)
    at shiftAwayBasePath (C:\work\projects\swisspush\apikana\src\path-v3-generator\path-v3-generator.js:419:13)
    at Object.createReadable [as readable] (C:\work\projects\swisspush\apikana\src\path-v3-generator\path-v3-generator.js:54:44)
    at Readable.read [as _read] (C:\work\projects\swisspush\apikana\src\generate.js:273:22)
    at Readable.read (_stream_readable.js:442:10)
    at resume_ (_stream_readable.js:822:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```
