### PR TITLE
Generic api ui

### DIFF
--- a/src/deps/helper.js
+++ b/src/deps/helper.js
@@ -63,7 +63,7 @@ $ = function (f) {
                     '#swagger-ui-container { display: none; }' +
                     '</style>').appendTo('body');
                 var title = ((spec.info || {}).title) || '';
-                var desc = ((spec.info || {}).description);
+                var desc = ((spec.info || {}).description || '');
                 var modelDiv = $('<div class="models"><h1>' + title + '</h1><p>' + desc + '</p></div>').appendTo('body');
                 for (var def in schema) {
                     if (isLocalSchema(models, schema[def])) {

--- a/src/deps/helper.js
+++ b/src/deps/helper.js
@@ -29,6 +29,7 @@ $ = function (f) {
         return;
     }
     var apiUrl = getAbsoluteUrl(url);
+    var models;
 
     fetchApi(apiUrl).then(function (json) {
         spec = json;
@@ -41,7 +42,7 @@ $ = function (f) {
         }
 
         var apiBase = apiUrl.substring(0, apiUrl.lastIndexOf('/') + 1);
-        var models = modelFiles(spec, apiBase);
+        models = modelFiles(spec, apiBase);
         if (models.length > 0) {
             return generateSchema(models);
         } else {
@@ -56,13 +57,14 @@ $ = function (f) {
             if (!spec.paths || spec.paths.length === 0) {
                 $('<style>' +
                     '.docson > .box { width: 600px; }' +
-                    '.models { font-family: sans-serif; margin: 50px auto; width: 600px; }' +
+                    '.models { font-family: sans-serif; margin: 12px auto; width: 600px; }' +
                     '.models > h1 { font-size: 25px; font-weight: 700; }' +
+                    '.models > * { margin-top: 20px; }' +
                     '#swagger-ui-container { display: none; }' +
                     '</style>').appendTo('body');
                 var title = ((spec.info || {}).title) || '';
-                var desc = ((spec.info || {}).description) || 'This module contains only models.';
-                var modelDiv = $('<div class="models"><h1>' + title + '</h1><span>' + desc + '</span></div>').appendTo('#header');
+                var desc = ((spec.info || {}).description);
+                var modelDiv = $('<div class="models"><h1>' + title + '</h1><p>' + desc + '</p></div>').appendTo('body');
                 for (var def in schema) {
                     if (isLocalSchema(models, schema[def])) {
                         $('<div class="docson">' + def + '</div>').appendTo(modelDiv);

--- a/src/plopfile_init.js
+++ b/src/plopfile_init.js
@@ -136,6 +136,7 @@ module.exports = function (plop, cfg) {
             var result = Object.entries({
                 'base': true,
                 'openapi': answers.type != 'api',
+                'generic': answers.type == 'api',
                 'rest': answers.type == 'rest-api',
                 'stream': answers.type == 'stream-api'
             })

--- a/src/scaffold/template/generic/src/style/custom-style.css
+++ b/src/scaffold/template/generic/src/style/custom-style.css
@@ -1,0 +1,4 @@
+#header {
+    display: none;
+}
+


### PR DESCRIPTION
UI Support for _generic APIs-, i.e. APIs that contain only models.
This PR just fixes a previous implementation of the generic api rendering.
Also, it adds a template for the generic apis with a custom style.