### PR TITLE
Upgrade to jsonschema2pojo 1.0.1 and use java date

### DIFF
--- a/src/scaffold/template/maven/gen/maven/pom.xml
+++ b/src/scaffold/template/maven/gen/maven/pom.xml
@@ -15,15 +15,16 @@
             <plugin>
                 <groupId>org.jsonschema2pojo</groupId>
                 <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-                <version>0.4.37</version>
+                <version>1.0.1</version>
                 <configuration>
-                    <sourceDirectory>../../dist/model/json-schema-v3</sourceDirectory>
+                    <targetPackage>{{ customConfig.javaPackage }}</targetPackage>
+                    <sourceDirectory>${basedir}/../../dist/model/json-schema-v3</sourceDirectory>
                     <includeJsr303Annotations>true</includeJsr303Annotations>
-                    <useJodaDates>true</useJodaDates>
-                    <useJodaLocalDates>true</useJodaLocalDates>
-                    <useJodaLocalTimes>true</useJodaLocalTimes>
+                    <includeJsr305Annotations>true</includeJsr305Annotations>
                     <generateBuilders>true</generateBuilders>
                     <removeOldOutput>true</removeOldOutput>
+                    <dateTimeType>java.time.ZonedDateTime</dateTimeType>
+                    <dateType>java.time.LocalDate</dateType>
                 </configuration>
                 <executions>
                     <execution>
@@ -33,6 +34,26 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <inherited>true</inherited>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <updateReleaseInfo>true</updateReleaseInfo>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -52,11 +73,6 @@
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <version>1.1.0.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.9.7</version>
         </dependency>
         {{#each (ConvertDependency dependencies)}}
         <dependency>


### PR DESCRIPTION
Upgraded jsonschema2pojo to 1.0.1.
Added default java date with ZonedDateTime for date-time types and LocalDate for date types.