### PR TITLE
Keep /src/ts directory structure in /dist

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "apikana",
-  "version": "0.7.2",
+  "version": "0.7.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apikana",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Integrated tools for REST API design - ｱﾋﾟ",
   "main": "index.js",
   "bin": {

--- a/src/generate-schema.js
+++ b/src/generate-schema.js
@@ -58,7 +58,7 @@ module.exports = {
                 //thank you MS for messing around with filenames!
                 var filename = normPath(schema.extra.filename);
                 var source = filename.toLowerCase().startsWith(normPath(deps).toLowerCase())
-                    ? (relDeps + '/json-schema-v4' + path.dirname(filename.substring(deps.length + 3)) + '/') : '';
+                    ? (relDeps + '/ts/' + path.dirname(filename.substring(filename.lastIndexOf('-api-dependencies/ts/') + 21, filename.lastIndexOf('/ts')+3)) + '/json-schema-v4/') : '';
                 infos[name] = {
                     source: source,
                     object: schema.type === 'object' || schema.enum || schema.allOf

--- a/src/generate.js
+++ b/src/generate.js
@@ -320,9 +320,8 @@ module.exports = {
 
         // copy local defined models to dist directory keeping the local folder structure.
         task('copy-ts-model', ['cleanup-dist', 'read-rest-api'], function () {
-           return gulp.src([params.models() + '/**/*.ts'], {cwd: source})
-                .pipe(gulp.dest(path.join('model', 'ts'), {cwd: dest}));
-
+           return gulp.src([path.join(source, 'ts') + '/**/*.ts'], {base: source})
+                .pipe(gulp.dest('model', {cwd: dest}));
         });
 
         // copy unpacked dependencies to node_modules in dist directory so it is possible to re-use the objects.

--- a/src/generate.js
+++ b/src/generate.js
@@ -318,52 +318,35 @@ module.exports = {
             return gulp.src('**/*', {cwd: source}).pipe(gulp.dest('src', {cwd: uiPath}));
         });
 
-        function getModelDirs(dir, folders) {
-            folders.push(dir.replace(/\\/g, '/')+'/*');
-            var files = fs.readdirSync(dir);
-            files.forEach(file => {
-                let fullPath = path.join(dir, file);
-                if (fs.lstatSync(fullPath).isDirectory()) {
-                    folders = getModelDirs(fullPath, folders);
-                }
-            });
-            return folders;
-        }
-
+        // copy local defined models to dist directory keeping the local folder structure.
         task('copy-ts-model', ['cleanup-dist', 'read-rest-api'], function () {
-            var folders = getModelDirs(path.join(source, 'ts'), []);
-            folders.forEach(folder => {
-                log.info('Copying models in:', colors.magenta(path.relative(source, folder)), 'folder to', colors.magenta('dist/model/ts/'));
-                gulp.src(folder, {base: path.join(source, 'ts')}).pipe(gulp.dest('model/ts/', {cwd: dest}));
-            });
-            return emptyStream();
+           return gulp.src([params.models() + '/**/*.ts'], {cwd: source})
+                .pipe(gulp.dest(path.join('model', 'ts'), {cwd: dest}));
+
         });
 
+        // copy unpacked dependencies to node_modules in dist directory so it is possible to re-use the objects.
         task('copy-ts-deps', ['unpack-models'], function() {
-            return gulp.src(params.dependencyPath()+'/ts/**/*.ts').pipe(gulp.dest('model/ts/node_modules/', {cwd: dest}));
+            return gulp.src([params.dependencyPath()+'/**/*.ts'], {base: params.dependencyPath()})
+                .pipe(gulp.dest(path.join('model', 'ts', 'node_modules'), {cwd: dest}));
         })
 
+        // unpack different things into -api-dependencies/ts keeping the original folder structure.
+        // the ts subdirectory is important because the front-end only understands dependencies under /ts/ dir.
         task('unpack-models', ['cleanup-dist'], function () {
             return merge(
                 unpack('dist/model', 'json-schema-v3', '**/*.json'),
                 unpack('dist/model', 'json-schema-v4', '**/*.json'),
                 unpack('dist/ui', 'style', '**/*', true),
                 unpack('dist/model', 'ts', '**/*.ts'),
-                gulp.src('src/model/ts/**/*.ts', {cwd: apikanaPath}).pipe(gulp.dest('ts/apikana', {cwd: dependencyPath}))
+                gulp.src('src/model/ts/**/*.ts', {cwd: apikanaPath}).pipe(gulp.dest('apikana', {cwd: dependencyPath}))
             );
         });
 
+        // copies files keeping the original structure. -api-dependencies is ignored because is the target (paste) directory.
         function unpack(baseDir, subDir, pattern, absolute) {
-            return gulp.src('**/node_modules/*/' + baseDir + '/' + subDir + '/' + pattern)
-                .pipe(rename(function (path) {
-                    var dir = path.dirname.replace(/\\/g, '/');
-                    dir = dir.substring(dir.lastIndexOf('node_modules/') + 13);
-                    var moduleEnd = dir.indexOf('/');
-                    var pathStart = dir.indexOf(subDir);
-                    dir = absolute ? dir.substring(pathStart) : (subDir + '/' + dir.substring(0, moduleEnd));
-                    path.dirname = dir;
-                }))
-                .pipe(gulp.dest(dependencyPath));
+            return gulp.src(['!./**/-api-dependencies/**/*', './**/node_modules/**/' + baseDir + '/' + subDir + '/' + pattern], {base: 'node_modules'})
+                .pipe(gulp.dest(path.join(params.dependencyPath())));
         }
 
         // TODO why should a dependency overwrite a local definition?

--- a/src/generate.js
+++ b/src/generate.js
@@ -327,9 +327,13 @@ module.exports = {
 
         // copy unpacked dependencies to node_modules in dist directory so it is possible to re-use the objects.
         task('copy-ts-deps', ['unpack-models'], function() {
-            return gulp.src([params.dependencyPath()+'/**/*.ts'], {base: params.dependencyPath()})
-                    .pipe(gulp.dest(path.join('model', 'ts', 'node_modules'), {cwd: dest}));
-        })
+            return merge(
+                    gulp.src([params.dependencyPath()+'/**/*.ts'], {base: params.dependencyPath()})
+                        .pipe(gulp.dest(path.join('model', 'ts', 'node_modules'), {cwd: dest})),
+                    gulp.src([params.dependencyPath()+'/**/*.ts'], {base: path.join(params.dependencyPath(), 'ts')})
+                        .pipe(gulp.dest(path.join('model', 'ts', 'node_modules'), {cwd: dest}))
+                    );
+        });
 
         // unpack dependencies under -api-dependencies/ts keeping the original folder structure.
         // NOTE: the 'ts' subdirectory is important because the front-end only understands dependencies under /ts/ dir.


### PR DESCRIPTION
On npm install:
1 get all dependencies and store them in <project_root>/node_modules as usual.

On apikana start:
2 copy all files in src/ts/**/*.ts in dist/model/ts keeping the structure defined in the project.
3 copy the apikana-defaults.ts file in <project_root>/node_modules/apikana. This is needed because we want to import "apikana/apikana-defaults" in the typescript models.
4 unpack external dependencies and copy them in <root_project>/node_modules/-api-dependencies/ts.
5 copy all <root_project>/node_modules/-api-dependencies/ts in dist/model/ts/node_modules/ts/ so that when testing locally, the dependencies are found and correctly displayed.
6 copy all <root__project>/node_modules/-api-dependencies/ts in dist/model/ts/node_modules/ so that when showing swagger through the node module (.tgz), the dependencies are correctly displayed.
