### PR TITLE
Freeze dependency to apikana-defaults

### DIFF
--- a/bin/apikana
+++ b/bin/apikana
@@ -125,7 +125,9 @@ function generate() {
     var defaultsVersion = packageJSON.devDependencies['apikana-defaults'];
 
     if (defaultsVersion) {
-        process.stdout.write("Using defaults:  " + defaultsVersion + "\n");
+        if(defaultsVersion != "0.0.0") {
+            process.stdout.write("Using defaults " + defaultsVersion + "\n");
+        }
         var defaultsDir = path.join(process.cwd(), 'node_modules', 'apikana-defaults');
         var defaults = require(defaultsDir);
         defaults.dir = defaultsDir
@@ -135,14 +137,14 @@ function generate() {
         manager.install('apikana-defaults').then((e) => {
             process.stdout.write("found "+e.version+"\n");
             var defaults = manager.require('apikana-defaults');
-            var defaultsDir = path.join(os.tmpdir(), 'apikana-plugin-packages', 'apikana-defaults');            
+            var defaultsDir = path.join(os.tmpdir(), 'apikana-plugin-packages', 'apikana-defaults');
             defaults.dir = defaultsDir;
             var version = JSON.parse(fs.readFileSync(path.join(defaultsDir, 'package.json'))).version;
             if(version != "0.0.0") {
-                log(colors.yellow(`WARNING: The build is unpredictable because of an implicit dependency.`));
-                log(colors.yellow(`         It may break anytime when a new version of the dependency is available in the registry.`));
-                log(colors.yellow(`         To fix this, freeze the dependency in your API project:`));
-                log(colors.yellow(`           npm install apikana-defaults@${version} --save-dev`));
+                log(colors.yellow(`WARNING: | The build is unpredictable because of an implicit dependency.`));
+                log(colors.yellow(`         | It may break anytime when a new version of the dependency is available in the registry.`));
+                log(colors.yellow(`         | To fix this, freeze the dependency in your API project:`));
+                log(colors.yellow(`         |  npm install apikana-defaults@${version} --save-dev`));
             }
             run(defaults);
         });

--- a/bin/apikana
+++ b/bin/apikana
@@ -122,16 +122,28 @@ function generate() {
         });
     }
 
-    if(packageJSON.dependencies['apikana-defaults']) {
-        run(require('apikana-defaults'));
+    var defaultsVersion = packageJSON.devDependencies['apikana-defaults'];
+
+    if (defaultsVersion) {
+        process.stdout.write("Using defaults:  " + defaultsVersion + "\n");
+        var defaultsDir = path.join(process.cwd(), 'node_modules', 'apikana-defaults');
+        var defaults = require(defaultsDir);
+        defaults.dir = defaultsDir
+        run(defaults);
     } else {
         process.stdout.write("Loading defaults... ");
         manager.install('apikana-defaults').then((e) => {
             process.stdout.write("found "+e.version+"\n");
             var defaults = manager.require('apikana-defaults');
-            var version = JSON.parse(fs.readFileSync(path.join(os.tmpdir(),'apikana-plugin-packages', 'apikana-defaults', 'package.json'))).version;
-            log(colors.yellow(`WARNING: The build is unpredictable because of missing explicit dependency.`));
-            log(colors.yellow(`         Add "apikana-defaults": "${version}" to "devDependencies" in package.json`));
+            var defaultsDir = path.join(os.tmpdir(), 'apikana-plugin-packages', 'apikana-defaults');            
+            defaults.dir = defaultsDir;
+            var version = JSON.parse(fs.readFileSync(path.join(defaultsDir, 'package.json'))).version;
+            if(version != "0.0.0") {
+                log(colors.yellow(`WARNING: The build is unpredictable because of an implicit dependency.`));
+                log(colors.yellow(`         It may break anytime when a new version of the dependency is available in the registry.`));
+                log(colors.yellow(`         To fix this, freeze the dependency in your API project:`));
+                log(colors.yellow(`           npm install apikana-defaults@${version} --save-dev`));
+            }
             run(defaults);
         });
     }

--- a/bin/apikana
+++ b/bin/apikana
@@ -92,14 +92,14 @@ function validateSamples() {
     require('../src/validate-samples').validate(path.resolve('.'));
 }
 
-function generate() { 
+function generate() {
     var source = 'src';
 
     if (argc > 3 && process.argv[3].substring(0, 2) !== '--') {
         source = process.argv[3];
     }
     params.readConfigFile();
-    
+
     log('Source: ', source);
 
     const nodePlop = require("node-plop");
@@ -114,16 +114,25 @@ function generate() {
         pluginsPath: path.join(os.tmpdir(), 'apikana-plugin-packages')
     });
 
-    process.stdout.write("Loading defaults... ");
-
-    manager.install('apikana-defaults').then((e) => {
-        process.stdout.write("found "+e.version+"\n");
-        var defaults = manager.require('apikana-defaults');
+    function run(defaults) {
         var plop = nodePlop(__dirname + '/../src/plopfile_start.js', { defaults });
         var generator = plop.getGenerator('start');
-
-        generator.runPrompts().then(_ => generator.runActions(packageJSON).then(_ => {
+        generator.runActions(packageJSON).then(_ => {
             require('../src/generate').generate(path.resolve(source), params.target());
-        }));
-    });
+        });
+    }
+
+    if(packageJSON.dependencies['apikana-defaults']) {
+        run(require('apikana-defaults'));
+    } else {
+        process.stdout.write("Loading defaults... ");
+        manager.install('apikana-defaults').then((e) => {
+            process.stdout.write("found "+e.version+"\n");
+            var defaults = manager.require('apikana-defaults');
+            var version = JSON.parse(fs.readFileSync(path.join(os.tmpdir(),'apikana-plugin-packages', 'apikana-defaults', 'package.json'))).version;
+            log(colors.yellow(`WARNING: The build is unpredictable because of missing explicit dependency.`));
+            log(colors.yellow(`         Add "apikana-defaults": "${version}" to "devDependencies" in package.json`));
+            run(defaults);
+        });
+    }
 }

--- a/src/init/init.js
+++ b/src/init/init.js
@@ -3,6 +3,7 @@ const registryUrl = require('registry-url');
 
 var os = require('os');
 var path = require('path');
+var fs = require('fs');
 
 const PluginManager = require('live-plugin-manager').PluginManager;
 const manager = new PluginManager({
@@ -15,8 +16,9 @@ process.stdout.write("Loading defaults... ");
 manager.install('apikana-defaults').then((e) => {
     process.stdout.write("found "+e.version+"\n");
     var defaults = manager.require('apikana-defaults');
+    var defaultsDir = path.join(os.tmpdir(), 'apikana-plugin-packages', 'apikana-defaults'); 
+    defaults.version = JSON.parse(fs.readFileSync(path.join(defaultsDir, 'package.json'))).version;
     var plop = nodePlop(__dirname + '/../plopfile_init.js', { defaults });
     var generator = plop.getGenerator('init');
-
     generator.runPrompts().then(config => generator.runActions(config));
 });

--- a/src/plopfile_init.js
+++ b/src/plopfile_init.js
@@ -178,7 +178,7 @@ module.exports = function (plop, cfg) {
                     // by default add default files directly from apikana
                     actions.push({
                         type: 'addMany',
-                        data: { apikanaVersion },
+                        data: { apikanaVersion, version: defaults && defaults.version },
                         globOptions: {dot: true},
                         destination: slash(path.join(currentPath, answers.projectName)),
                         base: slash(path.join(__dirname, 'scaffold', 'template', key)),
@@ -189,7 +189,7 @@ module.exports = function (plop, cfg) {
                     // overwrite all matching if apikana-defaults contains any
                     actions.push({
                         type: 'addMany',
-                        data: { apikanaVersion },
+                        data: { apikanaVersion, version: defaults && defaults.version },
                         globOptions: {dot: true},
                         destination: slash(path.join(currentPath, answers.projectName)),
                         base: slash(path.join(os.tmpdir(),'apikana-plugin-packages', 'apikana-defaults', 'templates', 'init', key)),

--- a/src/plopfile_start.js
+++ b/src/plopfile_start.js
@@ -5,6 +5,8 @@ const slash = require('slash');
 
 module.exports = function (plop, cfg) {
     const { defaults } = cfg;
+    const defaultsDir = defaults && defaults.dir || path.join(os.tmpdir(), 'apikana-plugin-packages', 'apikana-defaults')
+
     const currentPath = process.cwd();
     plop.setHelper('ConvertVersion', (version) => {
         return version.replace(/-(?!.*-).*/, "-SNAPSHOT");
@@ -56,8 +58,8 @@ module.exports = function (plop, cfg) {
                     type: 'addMany',
                     globOptions: {dot: true},
                     destination: currentPath,
-                    base: slash(path.join(os.tmpdir(),'apikana-plugin-packages', 'apikana-defaults', 'templates', 'start', plugin)),
-                    templateFiles: slash(path.join(os.tmpdir(),'apikana-plugin-packages', 'apikana-defaults', 'templates', 'start', plugin, '**')),
+                    base: slash(path.join(defaultsDir, 'templates', 'start', plugin)),
+                    templateFiles: slash(path.join(defaultsDir, 'templates', 'start', plugin, '**')),
                     force: true
                 });
 

--- a/src/scaffold/template/base/package.json
+++ b/src/scaffold/template/base/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
   },
   "devDependencies": {
-    "apikana": "{{ apikanaVersion }}"
+    "apikana": "{{ apikanaVersion }}",
+    "apikana-defaults": "{{ version }}"
   },
   "customConfig": {{{ json @root }}}
 }


### PR DESCRIPTION
Currently, apikana-defaults is updated automatically to the latest version.
This leads to unpredictable builds.
With this PR, apikana-defaults is kept as dev dependency for the "start" phase. The "init" phase still uses the latest version.
A warning is issued to encourage users of existing projects to freeze the dependency.