### PR TITLE
feat: public properties can have a leadingUnderscore

### DIFF
--- a/src/scaffold/template/base/.eslintrc.json
+++ b/src/scaffold/template/base/.eslintrc.json
@@ -60,6 +60,16 @@
                 "leadingUnderscore": "require"
             },
             {
+                "selector": "memberLike",
+                "modifiers": [
+                    "public"
+                ],
+                "format": [
+                    "camelCase"
+                ],
+                "leadingUnderscore": "allow"
+            },
+            {
                 "selector": "enumMember",
                 "format": [
                     "UPPER_CASE"


### PR DESCRIPTION
There could be the need of having a trailUnderscore in public property name.

In my company pagination is defined like this:
 `{ "items": [], "_metadata": {...} }`