### PR TITLE
Fix pet-event to not break linting

### DIFF
--- a/src/scaffold/template/stream/src/ts/pet-event.ts
+++ b/src/scaffold/template/stream/src/ts/pet-event.ts
@@ -1,5 +1,5 @@
-import {DateTime} from "apikana/default-types";
-import {Pet} from './pet';
+import { DateTime } from 'apikana/default-types'
+import { Pet } from './pet'
 
 export interface PetEvent {
     /**
@@ -31,5 +31,3 @@ export interface PetEvent {
         location: string
     }
 }
-
-


### PR DESCRIPTION
When creating a new apikana project with type `Stream` it reports 4 violations of linting rules. This is fixed with this PR.