### PR TITLE
respect models argument on copy-ts-model

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -338,8 +338,26 @@ module.exports = {
 
         // copy local defined models to dist directory keeping the local folder structure.
         task('copy-ts-model', ['cleanup-dist', 'read-rest-api'], function () {
-           return gulp.src([path.join(source, 'ts') + '/**/*.ts'], {base: source})
-                .pipe(gulp.dest('model', {cwd: dest}));
+            task('copy-ts-model', ['cleanup-dist', 'read-rest-api'], function () {
+                // SDCISA-4685 respect application argument 'models' to copy local ts
+                let sourcePaths;
+                let sourceOptions;
+                let destination;
+                if (params.models() && fs.existsSync(params.models())) {
+                    log.debug('Copying ts models from (arg) ', colors.magenta(params.models()));
+                    sourcePaths = [params.models() + '/**/*.ts'];
+                    sourceOptions = {cwd: source};
+                    destination = gulp.dest(path.join('model', 'ts'), {cwd: dest});
+                } else {
+                    log.debug('Copying ts models from (default) ', colors.magenta(path.join(source, 'ts')));
+                    sourcePaths = [path.join(source, 'ts') + '/**/*.ts'];
+                    sourceOptions = {base: source}
+                    destination = gulp.dest('model', {cwd: dest});
+                }
+
+                return gulp.src(sourcePaths, sourceOptions)
+                    .pipe(destination);
+            });
         });
 
         // copy unpacked dependencies to node_modules in dist directory so it is possible to re-use the objects.


### PR DESCRIPTION
All application arguments are affecting apikana on one way or the other to maintain flexibility on usage. Following #105 with [commit](https://github.com/swisspush/apikana/commit/b3e33879f36ff0422a7bf0abf2d56783ef1bbe82) removed the flexibility to have any project structure while copying ts files. The removal created SDCISA-4685 on our end, where we heavily make usage of application arguments to run apikana, due to our custom project structure.

We may understand that apikana is trying to compel the users to have a standart project structure for its usage, but then we expect the application argument `models` itself to be completely removed and not used in any task. Following PR is re-enabling this flexibility and also respecting the default structure, if `models` is not set and its path is not existent.