### PR TITLE
respect models argument on copy-ts-model

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -338,8 +338,24 @@ module.exports = {
 
         // copy local defined models to dist directory keeping the local folder structure.
         task('copy-ts-model', ['cleanup-dist', 'read-rest-api'], function () {
-           return gulp.src([path.join(source, 'ts') + '/**/*.ts'], {base: source})
-                .pipe(gulp.dest('model', {cwd: dest}));
+            let sourcePaths;
+            let sourceOptions;
+            let destination;
+            const defaultPath = path.join(source, 'ts');
+            if (fs.existsSync(defaultPath)) {
+                log.debug('Copying ts models from (default) ', colors.magenta(defaultPath));
+                sourcePaths = [defaultPath + '/**/*.ts'];
+                sourceOptions = {base: source}
+                destination = gulp.dest('model', {cwd: dest});
+            } else {
+                log.debug('Copying ts models from (arg) ', colors.magenta(params.models()));
+                sourcePaths = [params.models() + '/**/*.ts'];
+                sourceOptions = {cwd: source};
+                destination = gulp.dest(path.join('model', 'ts'), {cwd: dest});
+            }
+
+            return gulp.src(sourcePaths, sourceOptions)
+                .pipe(destination);
         });
 
         // copy unpacked dependencies to node_modules in dist directory so it is possible to re-use the objects.


### PR DESCRIPTION
All application arguments are affecting apikana on one way or the other to maintain flexibility on its usage. Following #105 with [commit](https://github.com/swisspush/apikana/commit/b3e33879f36ff0422a7bf0abf2d56783ef1bbe82) removed the flexibility to have any project structure while copying ts files. The removal created SDCISA-4685 on our end, where we heavily make usage of application arguments to run apikana, due to our custom project structure `src\model\ts` which also seems to be the old structure of apikana.

We may understand that apikana is trying to compel the users to have a standart project structure (input & output) for its usage, but then we expect the application argument `--models` itself to be completely removed and not used in any task. Following PR is re-enabling this flexibility and also respecting the default structure, by checking its existence. Otherwise it will fall back to `params.models()` which automatically gets set when `openapi.yaml` is parsed. This also means for our custom case, we can even now start apikana without adding the argument `--models`.

I will also take the questioned oppurtinity to keep the old output structure `api/model/ts` just to have it in line with our `openapi.yaml` references. I can guarantee that this should not happen for the new input structure `src/ts` because it is geting checked for existence before copying it to `api/model`.