### PR TITLE
Feature/implement version unspecific schema migration

### DIFF
--- a/src/generate-schema.js
+++ b/src/generate-schema.js
@@ -53,7 +53,7 @@ module.exports = {
                 convertToV3(schema, v3);
                 fs.writeFileSync(schemaFile(name, 'v3'), JSON.stringify(schema, null, 2));
                 migrator.draft7(schemaCopy);
-                fs.writeFileSync(schemaFile(name, 'v7'), JSON.stringify(schemaCopy, null, 2));
+                fs.writeFileSync(schemaFile(name, 'latest'), JSON.stringify(schemaCopy, null, 2));
             }
         }
 
@@ -214,7 +214,7 @@ module.exports = {
 function mkdirs(dest) {
     fse.mkdirsSync(schemaDir(dest, 'v3'));
     fse.mkdirsSync(schemaDir(dest, 'v4'));
-    fse.mkdirsSync(schemaDir(dest, 'v7'));
+    fse.mkdirsSync(schemaDir(dest, 'latest'));
 }
 
 function schemaDir(dest, version) {

--- a/src/generate-schema.js
+++ b/src/generate-schema.js
@@ -6,7 +6,7 @@ var fse = require('fs-extra');
 var path = require('path');
 var schemaGen = require('./schema-gen');
 var params = require('./params');
-var migrator = require("json-schema-migrate");
+var migrator = require("./schema-migrate");
 
 module.exports = {
     mkdirs: mkdirs,
@@ -47,13 +47,12 @@ module.exports = {
                 }
 
                 // Copy the schema to be able to cleanly migrate it to a newer draft version.
-                var schemaCopy = Object.assign({}, schema);
+                var latestSchema = migrator.migrateSchemaToLatestVersion(schema);
 
                 fs.writeFileSync(schemaFile(name, 'v4'), JSON.stringify(schema, null, 2));
                 convertToV3(schema, v3);
                 fs.writeFileSync(schemaFile(name, 'v3'), JSON.stringify(schema, null, 2));
-                migrator.draft7(schemaCopy);
-                fs.writeFileSync(schemaFile(name, 'latest'), JSON.stringify(schemaCopy, null, 2));
+                fs.writeFileSync(schemaFile(name, 'latest'), JSON.stringify(latestSchema, null, 2));
             }
         }
 

--- a/src/generate.js
+++ b/src/generate.js
@@ -561,12 +561,12 @@ module.exports = {
             var fullSchema = Object.assign({}, schema);
 
             var jsonSchemaOutputDirV4 = path.resolve(destination, 'model/json-schema-v4-full')
-            var jsonSchemaOutputDirV7 = path.resolve(destination, 'model/json-schema-v7-full')
+            var jsonSchemaOutputDirLatest = path.resolve(destination, 'model/json-schema-latest-full')
             fse.mkdirsSync(jsonSchemaOutputDirV4);
-            fse.mkdirsSync(jsonSchemaOutputDirV7);
+            fse.mkdirsSync(jsonSchemaOutputDirLatest);
             fs.writeFileSync(path.resolve(jsonSchemaOutputDirV4, fileName + '.json'), JSON.stringify(fullSchema, 6, 2));
             migrate.draft7(fullSchema)
-            fs.writeFileSync(path.resolve(jsonSchemaOutputDirV7, fileName + '.json'), JSON.stringify(fullSchema, 6, 2));
+            fs.writeFileSync(path.resolve(jsonSchemaOutputDirLatest, fileName + '.json'), JSON.stringify(fullSchema, 6, 2));
         }
 
         // Traverse the reference tree to keep only the needed definitions for the root schema

--- a/src/schema-migrate.js
+++ b/src/schema-migrate.js
@@ -1,0 +1,13 @@
+var migrator = require("json-schema-migrate");
+
+module.exports = {
+    migrateSchemaToLatestVersion: function (schema) {
+
+        var schemaCopy = Object.assign({}, schema);
+
+        // change the target latest schema version to migrate to here
+        migrator.draft7(schemaCopy);
+
+        return schemaCopy;
+    }
+}

--- a/test/specs/generate.spec.js
+++ b/test/specs/generate.spec.js
@@ -116,12 +116,12 @@ describe('generating', () => {
             expect(fs.existsSync(`${dir}/dist/model/json-schema-v3`))
                 .toBeTruthy());
 
-        it('should generate dist v7', () =>
-            expect(fs.existsSync(`${dir}/dist/model/json-schema-v7`))
+        it('should generate dist latest', () =>
+            expect(fs.existsSync(`${dir}/dist/model/json-schema-latest`))
                 .toBeTruthy());
 
-        it('dist v7 should not be empty', () =>
-            expect(fs.emptyDirSync(`${dir}/dist/model/json-schema-v7`))
+        it('dist latest should not be empty', () =>
+            expect(fs.emptyDirSync(`${dir}/dist/model/json-schema-latest`))
                 .toBeFalsy());
 
         it('should generate pom.xml', () =>
@@ -167,25 +167,25 @@ describe('generating', () => {
                 }
         });
 
-        it('generated schema json v7 files should have correct schema defined', () => {
-            var fileNames = fs.readdirSync(`${dir}/dist/model/json-schema-v7`);
+        it('generated schema json latest files should have correct schema defined', () => {
+            var fileNames = fs.readdirSync(`${dir}/dist/model/json-schema-latest`);
                 for(var i = 0; i < fileNames.length; i++){
-                    var json = JSON.parse(fs.readFileSync(`${dir}/dist/model/json-schema-v7/${fileNames[i]}`).toString('utf8'))
+                    var json = JSON.parse(fs.readFileSync(`${dir}/dist/model/json-schema-latest/${fileNames[i]}`).toString('utf8'))
 
                     expect(json.$schema)
-                        .toBe("http://json-schema.org/draft-07/schema");
+                        .toBe("http://json-schema.org/draft-07/schema"); // Adjust this test condition to the current latest draft version
                     expect(json.$id) // id property gets migrated with draft migration: id -> $id.
                         .toEqual(jasmine.anything());
                 }
         });
 
-        it('generated schema full json v7 file should have correct schema defined', () => {
-            var fileNames = fs.readdirSync(`${dir}/dist/model/json-schema-v7-full`);
+        it('generated schema full json latest file should have correct schema defined', () => {
+            var fileNames = fs.readdirSync(`${dir}/dist/model/json-schema-latest-full`);
                 for(var i = 0; i < fileNames.length; i++){
-                    var json = JSON.parse(fs.readFileSync(`${dir}/dist/model/json-schema-v7-full/${fileNames[i]}`).toString('utf8'))
+                    var json = JSON.parse(fs.readFileSync(`${dir}/dist/model/json-schema-latest-full/${fileNames[i]}`).toString('utf8'))
 
                     expect(json.$schema)
-                        .toBe("http://json-schema.org/draft-07/schema");
+                        .toBe("http://json-schema.org/draft-07/schema"); // Adjust this test condition to the current latest draft version
                     expect(json.$id)
                         .toEqual(jasmine.anything());
                     expect(json.definitions.Pet.properties.firstName.type)
@@ -247,8 +247,8 @@ describe('generating', () => {
                             .pipe(gulp.dest('node_modules/-api-dependencies/ts/wild-pet-rest-api/dist/model/ts', {cwd: mainDir})).on('finish', resolve)))
                 .then(() =>
                     new Promise(resolve =>
-                        gulp.src('dist/model/json-schema-v7/*.json', {cwd: depDir})
-                            .pipe(gulp.dest('node_modules/-api-dependencies/ts/wild-pet-rest-api/dist/model/json-schema-v7', {cwd: mainDir})).on('finish', resolve)))
+                        gulp.src('dist/model/json-schema-latest/*.json', {cwd: depDir})
+                            .pipe(gulp.dest('node_modules/-api-dependencies/ts/wild-pet-rest-api/dist/model/json-schema-latest', {cwd: mainDir})).on('finish', resolve)))
                 .then(() =>
                     new Promise(resolve =>
                         gulp.src('dist/model/json-schema-v4/*.json', {cwd: depDir})


### PR DESCRIPTION
- remove version specific schema migration
- support schema unspecific version migration

Migrated schemas will be available as "latest" schemas and not as a specific version.