### PR TITLE
fix: add repository url to have it as reference in the nuget package

### DIFF
--- a/src/scaffold/template/dotnet/gen/dotnet/api.csproj
+++ b/src/scaffold/template/dotnet/gen/dotnet/api.csproj
@@ -14,7 +14,7 @@
             If there is a suffix, the NuGet-Package will be treated as pre-release.
      -->
     <Version>{{ version }}</Version>
-
+    <RepositoryUrl>$(repositoryUrl)</RepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 


### PR DESCRIPTION
add repository url to have it as reference in the nuget package