### PR TITLE
feat!: upgrade to Java 21 and Jakarta in Maven scaffolder

### DIFF
--- a/src/scaffold/template/maven/gen/maven/pom.xml
+++ b/src/scaffold/template/maven/gen/maven/pom.xml
@@ -11,8 +11,8 @@
     <description>{{ customConfig.title }}</description>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <jackson-databind.version>2.9.9.3</jackson-databind.version>
     </properties>
@@ -22,11 +22,12 @@
             <plugin>
                 <groupId>org.jsonschema2pojo</groupId>
                 <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-                <version>1.0.1</version>
+                <version>1.2.2</version>
                 <configuration>
                     <targetPackage>{{ customConfig.javaPackage }}</targetPackage>
                     <sourceDirectory>${basedir}/../../dist/model/json-schema-v3</sourceDirectory>
                     <includeJsr303Annotations>true</includeJsr303Annotations>
+                    <useJakartaValidation>true</useJakartaValidation>
                     <generateBuilders>true</generateBuilders>
                     <removeOldOutput>true</removeOldOutput>
                     <dateTimeType>java.time.ZonedDateTime</dateTimeType>
@@ -86,9 +87,9 @@
             <version>${jackson-databind.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>1.1.0.Final</version>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.2</version>
         </dependency>
         {{#each (ConvertDependency dependencies)}}
         <dependency>


### PR DESCRIPTION
BREAKING CHANGE: The Maven scaffolder now requires Java 21 and Jakarta EE, which may cause incompatibility with projects using older Java versions or Java EE.